### PR TITLE
[it] - correction to cover expansion rule

### DIFF
--- a/sentences/it/_common.yaml
+++ b/sentences/it/_common.yaml
@@ -113,7 +113,7 @@ expansion_rules:
   set: "(impost(a|are) | cambi(a|are) | mett(i|ere) | modific(a|are))"
   temp: "[la] (temperatura)"
   temperature: "{temperature}[°| gradi] [{temperature_unit}]"
-  cover: (tend(a|e)[ da sole]|serrand(a|e)|tapparell(a|e)|persian(a|e)|port(a|e)|saracinesc(a|he)|venezian(a|e)|cancell(o|i)|finestr(a|i))
+  cover: (tend(a|e)[ da sole]|serrand(a|e)|tapparell(a|e)|persian(a|e)|port(a|e)|saracinesc(a|he)|venezian(a|e)|cancell(o|i)|finestr(a|e))
   fan: "(ventol(a|e) | ventilator(e|i) | ventilazione | climatizzator(e|i) | condizionator(e|i))"
 skip_words:
   - "per favore"


### PR DESCRIPTION
finestr(a|i) changed to finestr(a|e)